### PR TITLE
Fix received euro amount from Skier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+/500EuroForSkier/Properties
+/.vs/500EurosForSkier.slnx/v18
+/.vs/500EuroForSkier

--- a/500EuroForSkier/500EuroForSkier.csproj
+++ b/500EuroForSkier/500EuroForSkier.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <!-- The two lines below will set the output path for the binaries -->
         <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/500EuroForSkier/EuroForSkier.cs
+++ b/500EuroForSkier/EuroForSkier.cs
@@ -45,12 +45,16 @@ public class EuroForSkier(DatabaseServer databaseServer, ISptLogger<EuroForSkier
 
     private double? ExchangeCurrency(double? amt)
     {
-        return amt / _exchangeRate;
+        var exchangedCurrency = amt / _exchangeRate;
+        if(exchangedCurrency is null) return amt;
+        return Math.Floor(exchangedCurrency.Value);
     }
 
     private long? ExchangeCurrency(long? amt)
     {
-        return amt / (long?)_exchangeRate;
+        var exchangedCurrency = amt / _exchangeRate;
+        if(exchangedCurrency is null) return amt;
+        return (long)Math.Floor(exchangedCurrency.Value);
     }
 
     private void ConvertBarterCurrency(Trader trader)
@@ -74,9 +78,13 @@ public class EuroForSkier(DatabaseServer databaseServer, ISptLogger<EuroForSkier
             foreach (var item in reward.Items)
             {
                 if (item.Template != ItemTpl.MONEY_ROUBLES) continue;
-                var original = reward.Value;
-                reward.Value = ExchangeCurrency(original);
                 item.Template = ItemTpl.MONEY_EUROS;
+
+                var newValue = ExchangeCurrency(reward.Value);
+                reward.Value = newValue;
+
+                if (item.Upd == null) continue;
+                item.Upd.StackObjectsCount = newValue;
             }
         }
     }


### PR DESCRIPTION
- Floored exchanged value to prevent inconsistencies between received amount and displayed amount in quest description
- Assigned exchanged value to item.Upd.StackObjectsCount seems to fix
- Upped version to 1.0.3

Sometimes, there is still a +- 1 euro mismatch between received and displayed in quest description but I don't know why