### PR TITLE
prevent currency conversion from returning 0

### DIFF
--- a/500EuroForSkier/EuroForSkier.cs
+++ b/500EuroForSkier/EuroForSkier.cs
@@ -47,14 +47,16 @@ public class EuroForSkier(DatabaseServer databaseServer, ISptLogger<EuroForSkier
     {
         var exchangedCurrency = amt / _exchangeRate;
         if(exchangedCurrency is null) return amt;
-        return Math.Floor(exchangedCurrency.Value);
+        var flooredValue = Math.Floor(exchangedCurrency.Value);
+        return flooredValue == 0 ? 1 : flooredValue;
     }
 
     private long? ExchangeCurrency(long? amt)
     {
         var exchangedCurrency = amt / _exchangeRate;
         if(exchangedCurrency is null) return amt;
-        return (long)Math.Floor(exchangedCurrency.Value);
+        var flooredValue = (long)Math.Floor(exchangedCurrency.Value);
+        return flooredValue == 0 ? 1 : flooredValue;
     }
 
     private void ConvertBarterCurrency(Trader trader)


### PR DESCRIPTION
An issue was reported on Forge. 

Some ammo on the store of Skier were not available for purchase with a tooltip saying "The trader doesn’t want to buy it from you because of low standing".

This issue was cause by the fact that the conversion would calculate the cost of the ammo between 0 and 1 euros, then the Math.Floor would make it 0.

The ammo costing 0 was the source of the problem. 

The fix was simply to add a check to the currency conversion to prevent returning 0, returning 1 instead.

