### PR TITLE
replaced floor with 0 check with Ceiling instead

### DIFF
--- a/500EuroForSkier/EuroForSkier.cs
+++ b/500EuroForSkier/EuroForSkier.cs
@@ -47,16 +47,14 @@ public class EuroForSkier(DatabaseServer databaseServer, ISptLogger<EuroForSkier
     {
         var exchangedCurrency = amt / _exchangeRate;
         if(exchangedCurrency is null) return amt;
-        var flooredValue = Math.Floor(exchangedCurrency.Value);
-        return flooredValue == 0 ? 1 : flooredValue;
+        return Math.Ceiling(exchangedCurrency.Value);
     }
 
     private long? ExchangeCurrency(long? amt)
     {
         var exchangedCurrency = amt / _exchangeRate;
         if(exchangedCurrency is null) return amt;
-        var flooredValue = (long)Math.Floor(exchangedCurrency.Value);
-        return flooredValue == 0 ? 1 : flooredValue;
+        return (long)Math.Ceiling(exchangedCurrency.Value);
     }
 
     private void ConvertBarterCurrency(Trader trader)


### PR DESCRIPTION
Replaced the combination of Math.Floor and the 0 check with a Math.Ceiling (don't know what I was thinking when doing that).

It seems to fix the bug reported on Forge explaining that Skier's shop would be empty after the first raid of a new save file